### PR TITLE
chore: override travis setup releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
 deploy:
   provider: releases
   api_key:
-    secure: QCzmdW0PoMqaJt+wNMWWth7UH4cDxnLSVAP3A2tEGnx7nNrS63cH2Hk5p2k8hgSkdZ4kEuQDfrIeb/xPKGacbtQGNuJKiUWMINtdWScgiR3PXioYKnhDCv80DO6bVRCFsqXD0pIev32uive3prFPb1BhEfwlnUY2eeCbWPMYJII=
+    secure: n/N9zRGEXB13b26Z9vfH1nxomftOW61Raj8WwYJJbNcL5op3/Sx0wM1iI//y+XPwJ0Y5cktaSaS9rlKLcf6aUfQJYTLGBiD5ZzBHkVl9T6C1POLZF/1we1oQuAl1bk2G+9Z49gkT6Ul3CRf698S9M0nciPN+q7Bm6+bt+rOb90QHJNRisjyOn/tiQjgdH6leIOaxEkkCy0t7kqRv6P+eLdDSr7SwYHTWI6HmHJv6S7nR3ulSgNQNKVxIe9e/TZovNIoourXm1qm67YOuqJk2oTe6qE+z++FpVfIeUUyLOAb/FcOTSmnFXWnq0g7AG5u8ggc2DyKp//xeKd9Z4DK3+kEiItueKWenMNn34OXDiOzqcwp41EFg4QaK0U9mT8uPTkYuJ2c1h1fEk2NxeQHPtaoIeRqJhjzbXwuCdxCsFwPUxEysWmrfI2DbXKSSDm6jMjNbW+s8ta9YOhvieQzWLwuKP/iaKzrRaO8Twj31Nb/FRV0yMzV/L9vXNClmHttmV5qLWuxotN+8ww/JyFSbW8IQndIO6I7xIGi71Y7DNXggC9dEczQJKHYuasfLzetBIShqKGNnG9Z6+J/BIXBJBU5ZDhefuuunAet1DupHCD0qHSE1p4ggkNCtNedr4ciPvkXenbiD2gGgZoxb1uONN/D72knR/lXDjVKlEedkxy0=
   file_glob: true
   file: "./target/verify*.jar"
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ deploy:
   on:
     branch: add-secret
     jdk: openjdk8
-    # tags: true
+    tags: true
     repo: appium/verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 sudo: false
 jdk: openjdk8
-
 jobs:
   include:
     - stage:
@@ -13,35 +12,34 @@ jobs:
           else
             ./build.sh
           fi
-      script: ./test.sh
+      script: "./test.sh"
     - stage:
       name: JDK 9
       jdk: openjdk9
-      before_script: ./build.sh
-      script: ./test.sh
+      before_script: "./build.sh"
+      script: "./test.sh"
     - stage:
       name: JDK 10
       jdk: openjdk10
-      before_script: ./build.sh
-      script: ./test.sh
+      before_script: "./build.sh"
+      script: "./test.sh"
     - stage:
       name: JDK 11
       jdk: openjdk11
-      before_script: ./build.sh
-      script: ./test.sh
+      before_script: "./build.sh"
+      script: "./test.sh"
     - stage:
       name: JDK 12
       jdk: openjdk12
-      before_script: ./build.sh
-      script: ./test.sh
-
+      before_script: "./build.sh"
+      script: "./test.sh"
 deploy:
   provider: releases
   api_key:
-    secure: "TBD"
+    secure: QCzmdW0PoMqaJt+wNMWWth7UH4cDxnLSVAP3A2tEGnx7nNrS63cH2Hk5p2k8hgSkdZ4kEuQDfrIeb/xPKGacbtQGNuJKiUWMINtdWScgiR3PXioYKnhDCv80DO6bVRCFsqXD0pIev32uive3prFPb1BhEfwlnUY2eeCbWPMYJII=
   file_glob: true
-  file: ./target/verify*.jar
-  skip_cleanup: true
+  file: "./target/verify*.jar"
   on:
     jdk: openjdk8
     tags: true
+    repo: appium/verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ deploy:
   file_glob: true
   file: "./target/verify*.jar"
   on:
-    branch: add-secret
+    branch: master
     jdk: openjdk8
     tags: true
     repo: appium/verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ deploy:
   file_glob: true
   file: "./target/verify*.jar"
   on:
+    branch: add-secret
     jdk: openjdk8
-    tags: true
+    # tags: true
     repo: appium/verify


### PR DESCRIPTION
I ran `travis setup releases` as https://docs.travis-ci.com/user/deployment/releases/#authenticating-with-an-oauth-token

Maybe the API token works for GitHub release..
The `travis setup releases` regenerate the deploy section